### PR TITLE
Fix Debug Assert  in CmdPartDesignDuplicateSelection::activated

### DIFF
--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -295,6 +295,8 @@ void CmdPartDesignDuplicateSelection::activated(int iMsg)
     // Find the features that were added
     std::vector<App::DocumentObject*> afterFeatures = getDocument()->getObjects();
     std::vector<App::DocumentObject*> newFeatures;
+    std::sort(beforeFeatures.begin(), beforeFeatures.end());
+    std::sort(afterFeatures.begin(), afterFeatures.end());
     std::set_difference(afterFeatures.begin(), afterFeatures.end(), beforeFeatures.begin(), beforeFeatures.end(),
                         std::back_inserter(newFeatures));
 


### PR DESCRIPTION
Under Windows, "Edit/Duplicate selected object" raised a Debug Assertion Failed "Expression: sequence not ordered".
