### PR TITLE
Assembly merge master1 fix crashes

### DIFF
--- a/src/Mod/PartDesign/App/Body.cpp
+++ b/src/Mod/PartDesign/App/Body.cpp
@@ -230,12 +230,75 @@ const bool Body::isAllowed(const App::DocumentObject* f)
             );
 }
 
+
 void Body::addFeature(App::DocumentObject *feature)
 {
+    insertFeatureAfter (feature, Tip.getValue());
+
+    // Move the Tip
+    Tip.setValue (feature);
+}
+
+void Body::insertFeatureAfter(App::DocumentObject *feature, App::DocumentObject *after)
+{
+    // Check if the after feature belongs to the body
+    if (after && !hasFeature (after)) {
+        throw Base::Exception("Body: the feature we should insert after is not part of that body");
+    }
+
+    // Insert the new feature after the current Tip feature
+    std::vector<App::DocumentObject*> model = Model.getValues();
+    // Find the position there to insert the feature
+    App::DocumentObject* tipFeature = Tip.getValue();
+    std::vector<App::DocumentObject*>::iterator insertInto;
+
+    if (!tipFeature) {
+        // Insert feature as before all other features in the body (if there are any)
+        insertInto = model.begin();
+    } else {
+        // Insert after Tip
+        std::vector<App::DocumentObject*>::iterator afterIt = std::find (model.begin(), model.end(), tipFeature);
+        assert (afterIt != model.end());
+        insertInto = afterIt + 1;
+    }
+
+    // Insert the new feature after the given
+    model.insert (insertInto, feature);
+    Model.setValues (model);
+}
+
+
+void Body::insertFeatureBefore(App::DocumentObject *feature, App::DocumentObject *before)
+{
+    // Check if the after feature belongs to the body
+    if (before && !hasFeature (before)) {
+        throw Base::Exception("Body: the feature we should insert before is not part of that body");
+    }
+
+    // Find out the position there to insert the feature
+    std::vector<App::DocumentObject*> model = Model.getValues();
+    std::vector<App::DocumentObject*>::iterator insertInto;
+
+    if (!before) {
+        insertInto = model.end();
+    } else {
+        insertInto = std::find(model.begin(), model.end(), before);;
+        assert (insertInto != model.end());
+    }
+
+    setupInsertedFeature (feature);
+
+    // Insert the new feature after the given
+    model.insert (insertInto, feature);
+    Model.setValues (model);
+}
+
+
+void Body::setupInsertedFeature(App::DocumentObject* feature) {
     // Set the BaseFeature property
     if (feature->getTypeId().isDerivedFrom(PartDesign::Feature::getClassTypeId())) {
         App::DocumentObject* prevSolidFeature = getPrevSolidFeature(NULL, true);
-        if (prevSolidFeature != NULL)
+        if (prevSolidFeature)
             // Set BaseFeature property to previous feature (this might be the Tip feature)
             static_cast<PartDesign::Feature*>(feature)->BaseFeature.setValue(prevSolidFeature);
     }
@@ -243,37 +306,11 @@ void Body::addFeature(App::DocumentObject *feature)
     if (Body::isSolidFeature(feature)) {
         // Reroute the next solid feature's BaseFeature property to this feature
         App::DocumentObject* nextSolidFeature = getNextSolidFeature(NULL, false);
-        if (nextSolidFeature != NULL)
+        if (nextSolidFeature)
             static_cast<PartDesign::Feature*>(nextSolidFeature)->BaseFeature.setValue(feature);
     }
-
-    // Insert the new feature after the current Tip feature
-    App::DocumentObject* tipFeature = Tip.getValue();
-    std::vector<App::DocumentObject*> model = Model.getValues();
-    if (tipFeature == NULL) {
-        if (model.empty())
-            // First feature in the body
-            model.push_back(feature);
-        else
-            // Insert feature as before all other features in the body
-            model.insert(model.begin(), feature);
-    } else {
-        // Insert after Tip
-        std::vector<App::DocumentObject*>::iterator it = std::find(model.begin(), model.end(), tipFeature);
-        if (it == model.end())
-            throw Base::Exception("Body: Tip is not contained in model");
-
-        it++;
-        if (it == model.end())
-            model.push_back(feature);
-        else
-            model.insert(it, feature);
-    }
-    Model.setValues(model);
-
-    // Move the Tip
-    Tip.setValue(feature);
 }
+
 
 void Body::removeFeature(App::DocumentObject* feature)
 {
@@ -326,6 +363,7 @@ void Body::removeFeature(App::DocumentObject* feature)
     model.erase(it);
     Model.setValues(model);
 }
+
 
 bool Body::isFeature(App::DocumentObject* feature)
 {

--- a/src/Mod/PartDesign/App/Body.cpp
+++ b/src/Mod/PartDesign/App/Body.cpp
@@ -226,7 +226,7 @@ const bool Body::isAllowed(const App::DocumentObject* f)
             f->getTypeId().isDerivedFrom(Part::Datum::getClassTypeId())   ||
             f->getTypeId().isDerivedFrom(Part::Part2DObject::getClassTypeId()) ||
             //f->getTypeId().isDerivedFrom(Part::FeaturePython::getClassTypeId()) // trouble with this line on Windows!? Linker fails to find getClassTypeId() of the Part::FeaturePython...
-            f->getTypeId().isDerivedFrom(Part::Feature::getClassTypeId()) 
+            f->getTypeId().isDerivedFrom(Part::Feature::getClassTypeId())
             );
 }
 
@@ -368,13 +368,12 @@ void Body::removeFeature(App::DocumentObject* feature)
 bool Body::isFeature(App::DocumentObject* feature)
 {
     for(App::DocumentObject* obj : Model.getValues()) {
-        
+
         if(obj == feature)
             return true;
     }
     return false;
 }
-
 
 App::DocumentObjectExecReturn *Body::execute(void)
 {
@@ -403,7 +402,7 @@ App::DocumentObjectExecReturn *Body::execute(void)
         return App::DocumentObject::StdReturn;
 
     Shape.setValue(TipShape);
-    
+
     return App::DocumentObject::StdReturn;
 }
 
@@ -454,7 +453,7 @@ PyObject *Body::getPyObject(void)
         // ref counter is set to 1
         PythonObject = Py::Object(new BodyPy(this),true);
     }
-    return Py::new_reference_to(PythonObject); 
+    return Py::new_reference_to(PythonObject);
 }
 
 }

--- a/src/Mod/PartDesign/App/Body.h
+++ b/src/Mod/PartDesign/App/Body.h
@@ -81,9 +81,28 @@ public:
     /// Add the feature into the body at the current insert point (Tip feature)
     void addFeature(App::DocumentObject* feature);
 
+    /**
+	 * Insert the feature into the body after the given feature.
+	 *
+	 * @param feature  The feature to insert into the body
+	 * @param after    The feature after the given one should be inserted.
+	 *                 If after is NULL than insert to the begin of the body.
+	 * @note the methode doesn't modifies the Tip
+	 */
+    void insertFeatureAfter(App::DocumentObject* feature, App::DocumentObject* after);
+
+    /**
+	 * Insert the feature into the body before the given feature.
+	 *
+	 * @param feature  The feature to insert into the body
+	 * @param before   The feature before the given one should be inserted.
+	 *                 If before is NULL than insert to the end of feature list.
+	 */
+    void insertFeatureBefore(App::DocumentObject* feature, App::DocumentObject* before);
+
     /// Remove the feature from the body
     void removeFeature(App::DocumentObject* feature);
-    
+
     /// Checks if the given document object is a feaure of this body
     bool isFeature(App::DocumentObject* feature);
 
@@ -107,6 +126,10 @@ public:
     Base::BoundBox3d getBoundBox();
 
     PyObject *getPyObject(void);
+
+private:
+	/// A common code for add/insertFeature functions
+	void setupInsertedFeature(App::DocumentObject* feature);
 
 private:
     App::DocumentObject* rememberTip;

--- a/src/Mod/PartDesign/App/Body.h
+++ b/src/Mod/PartDesign/App/Body.h
@@ -48,7 +48,7 @@ public:
     //@{
     /// recalculate the feature
     App::DocumentObjectExecReturn *execute(void);
-    short mustExecute() const;    
+    short mustExecute() const;
     /// returns the type name of the view provider
     const char* getViewProviderName(void) const {
         return "PartDesignGui::ViewProviderBody";
@@ -82,22 +82,22 @@ public:
     void addFeature(App::DocumentObject* feature);
 
     /**
-	 * Insert the feature into the body after the given feature.
-	 *
-	 * @param feature  The feature to insert into the body
-	 * @param after    The feature after the given one should be inserted.
-	 *                 If after is NULL than insert to the begin of the body.
-	 * @note the methode doesn't modifies the Tip
-	 */
+     * Insert the feature into the body after the given feature.
+     *
+     * @param feature  The feature to insert into the body
+     * @param after    The feature after the given one should be inserted.
+     *                 If after is NULL than insert to the begin of the body.
+     * @note the methode doesn't modifies the Tip
+     */
     void insertFeatureAfter(App::DocumentObject* feature, App::DocumentObject* after);
 
     /**
-	 * Insert the feature into the body before the given feature.
-	 *
-	 * @param feature  The feature to insert into the body
-	 * @param before   The feature before the given one should be inserted.
-	 *                 If before is NULL than insert to the end of feature list.
-	 */
+     * Insert the feature into the body before the given feature.
+     *
+     * @param feature  The feature to insert into the body
+     * @param before   The feature before the given one should be inserted.
+     *                 If before is NULL than insert to the end of feature list.
+     */
     void insertFeatureBefore(App::DocumentObject* feature, App::DocumentObject* before);
 
     /// Remove the feature from the body
@@ -128,8 +128,8 @@ public:
     PyObject *getPyObject(void);
 
 private:
-	/// A common code for add/insertFeature functions
-	void setupInsertedFeature(App::DocumentObject* feature);
+    /// A common code for add/insertFeature functions
+    void setupInsertedFeature(App::DocumentObject* feature);
 
 private:
     App::DocumentObject* rememberTip;

--- a/src/Mod/PartDesign/App/BodyPy.xml
+++ b/src/Mod/PartDesign/App/BodyPy.xml
@@ -23,5 +23,26 @@
                     <UserDocu>removeFeature(feat) - Remove the given feature from the Body</UserDocu>
             </Documentation>
     </Methode>
+    <Methode Name="insertFeatureAfter">
+            <Documentation>
+                    <UserDocu>insertFeatureAfter(feature, after)
+                        Insert the feature into the body after the given feature.
+                        @param feature  The feature to insert into the body
+                        @param after    The feature after the given one should be inserted.
+                                        If after is None than insert the feature as first.
+                    </UserDocu>
+            </Documentation>
+    </Methode>
+    <Methode Name="insertFeatureBefore">
+            <Documentation>
+                    <UserDocu>insertFeatureBefore(feature, before)
+                        Insert the feature into the body before the given feature.
+                        @param feature  The feature to insert into the body
+                        @param before   The feature before the given one should be inserted.
+                                        If before is None than insert the feature as last.
+                        Note: the methode doesn't modifies the Tip
+                    </UserDocu>
+            </Documentation>
+    </Methode>
   </PythonExport>
 </GenerateModel>

--- a/src/Mod/PartDesign/App/BodyPyImp.cpp
+++ b/src/Mod/PartDesign/App/BodyPyImp.cpp
@@ -25,7 +25,7 @@ PyObject *BodyPy::getCustomAttributes(const char* /*attr*/) const
 
 int BodyPy::setCustomAttributes(const char* /*attr*/, PyObject* /*obj*/)
 {
-    return 0; 
+    return 0;
 }
 
 PyObject* BodyPy::addFeature(PyObject *args)

--- a/src/Mod/PartDesign/App/BodyPyImp.cpp
+++ b/src/Mod/PartDesign/App/BodyPyImp.cpp
@@ -52,6 +52,47 @@ PyObject* BodyPy::addFeature(PyObject *args)
     Py_Return;
 }
 
+// a shared implementation insertFeature{Before,After} funcs
+static PyObject* _do_insertFeature(BodyPy *bodyPy,
+        PyObject *args,
+        void (Body::*insertFunc)(App::DocumentObject*,  App::DocumentObject*))
+{
+
+    PyObject* featurePy;
+    PyObject* targetPy;
+    if (!PyArg_ParseTuple(args, "O!O", &(App::DocumentObjectPy::Type), &featurePy, &targetPy)) {
+        return 0;
+    }
+
+    App::DocumentObject* feature = static_cast<App::DocumentObjectPy*>(featurePy)->getDocumentObjectPtr();
+    App::DocumentObject* target = static_cast<App::DocumentObjectPy*>(targetPy)->getDocumentObjectPtr();
+
+    if (!Body::isAllowed(feature)) {
+        PyErr_SetString(PyExc_SystemError, "Only PartDesign features, datum features and sketches can be inserted into a Body");
+        return 0;
+    }
+    Body* body = bodyPy->getBodyPtr();
+
+    try {
+        (body->*insertFunc)(feature, target);
+    } catch (Base::Exception& e) {
+        PyErr_SetString(PyExc_SystemError, e.what());
+        return 0;
+    }
+
+    Py_Return;
+}
+
+PyObject* BodyPy::insertFeatureBefore(PyObject *args)
+{
+    return _do_insertFeature(this, args, &Body::insertFeatureBefore);
+}
+
+PyObject* BodyPy::insertFeatureAfter(PyObject *args)
+{
+    return _do_insertFeature(this, args, &Body::insertFeatureAfter);
+}
+
 PyObject* BodyPy::removeFeature(PyObject *args)
 {
     PyObject* featurePy;

--- a/src/Mod/PartDesign/App/FeatureDraft.cpp
+++ b/src/Mod/PartDesign/App/FeatureDraft.cpp
@@ -225,7 +225,7 @@ App::DocumentObjectExecReturn *Draft::execute(void)
                     if (refEdge.IsNull())
                         throw Base::Exception("Failed to extract neutral plane reference edge");
                     BRepAdaptor_Curve c(refEdge);
-                    if (!c.GetType() == GeomAbs_Line)
+                    if (c.GetType() != GeomAbs_Line)
                         throw Base::Exception("Neutral plane reference edge must be linear");
                     double a = c.Line().Angle(gp_Lin(c.Value(c.FirstParameter()), pullDirection));
                     if (std::fabs(a - M_PI_2) > Precision::Confusion())

--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -371,12 +371,17 @@ void CmdPartDesignMoveFeature::activated(int iMsg)
     for (std::vector<App::DocumentObject*>::const_iterator f = features.begin(); f != features.end(); f++) {
         // Find body of this feature
         Part::BodyBase* source = PartDesign::Body::findBodyOf(*f);
-        if (source == target) continue;
-        bool featureIsTip = (source->Tip.getValue() == *f);
+        bool featureIsTip = false;
 
-        // Remove from source body
-        doCommand(Doc,"App.activeDocument().%s.removeFeature(App.activeDocument().%s)",
+        if (source == target) continue;
+
+        // Remove from source body if the feature belongs to a body
+        if (source) {
+            featureIsTip = (source->Tip.getValue() == *f);
+            doCommand(Doc,"App.activeDocument().%s.removeFeature(App.activeDocument().%s)",
                       source->getNameInDocument(), (*f)->getNameInDocument());
+        }
+
         // Add to target body (always at the Tip)
         doCommand(Doc,"App.activeDocument().%s.addFeature(App.activeDocument().%s)",
                       target->getNameInDocument(), (*f)->getNameInDocument());
@@ -388,14 +393,16 @@ void CmdPartDesignMoveFeature::activated(int iMsg)
             // If we removed the tip of the source body, make the new tip visible
             if (featureIsTip) {
                 App::DocumentObject* prevSolidFeature = source->getPrevSolidFeature();
-                doCommand(Gui,"Gui.activeDocument().show(\"%s\")", prevSolidFeature->getNameInDocument());
+                if (prevSolidFeature) {
+                    doCommand(Gui,"Gui.activeDocument().show(\"%s\")", prevSolidFeature->getNameInDocument());
+                }
             }
 
             // Hide old tip and show new tip (the moved feature) of the target body
             App::DocumentObject* prevSolidFeature = target->getPrevSolidFeature();
             doCommand(Gui,"Gui.activeDocument().hide(\"%s\")", prevSolidFeature->getNameInDocument());
             doCommand(Gui,"Gui.activeDocument().show(\"%s\")", (*f)->getNameInDocument());
-        }
+        }  
     }
 }
 

--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -463,13 +463,6 @@ void CmdPartDesignMoveFeatureInTree::activated(int iMsg)
 
     openCommand("Move an object inside tree");
 
-    // Set insert point at the selected feature
-    App::DocumentObject* oldTip = pcActiveBody->Tip.getValue();
-    Gui::Selection().clearSelection();
-    if (target != NULL)
-        Gui::Selection().addSelection(target->getDocument()->getName(), target->getNameInDocument());
-    Gui::Command::doCommand(Gui::Command::Gui,"FreeCADGui.runCommand('PartDesign_MoveTip')");
-
     for (std::vector<App::DocumentObject*>::const_iterator f = features.begin(); f != features.end(); f++) {
         if (*f == target) continue;
 
@@ -478,17 +471,13 @@ void CmdPartDesignMoveFeatureInTree::activated(int iMsg)
         // feature as before!
         doCommand(Doc,"App.activeDocument().%s.removeFeature(App.activeDocument().%s)",
                       pcActiveBody->getNameInDocument(), (*f)->getNameInDocument());
-        doCommand(Doc,"App.activeDocument().%s.addFeature(App.activeDocument().%s)",
-                      pcActiveBody->getNameInDocument(), (*f)->getNameInDocument());
+        doCommand(Doc,
+                "App.activeDocument().%s.insertFeatureAfter(App.activeDocument().%s, App.activeDocument().%s,)",
+                pcActiveBody->getNameInDocument(), (*f)->getNameInDocument(), target->getNameInDocument());
     }
 
     // Recompute to update the shape
     doCommand(Gui,"App.activeDocument().recompute()");
-    // Set insert point where it was before
-    Gui::Selection().clearSelection();
-    Gui::Selection().addSelection(oldTip->getDocument()->getName(), oldTip->getNameInDocument());
-    Gui::Command::doCommand(Gui::Command::Gui,"FreeCADGui.runCommand('PartDesign_MoveTip')");
-    Gui::Selection().clearSelection();
 }
 
 bool CmdPartDesignMoveFeatureInTree::isActive(void)

--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -110,7 +110,7 @@ void CmdPartDesignPart::activated(int iMsg)
     doCommand(Doc,"App.activeDocument().Tip = App.activeDocument().addObject('App::Part','%s')",PartName.c_str());
     doCommand(Doc,"App.activeDocument().ActiveObject.Label = '%s'", QObject::tr(PartName.c_str()).toStdString().c_str());
     PartDesignGui::Workbench::setUpPart(dynamic_cast<App::Part *>(getDocument()->getObject(PartName.c_str())));
-    
+
     updateActive();
 }
 
@@ -144,7 +144,7 @@ void CmdPartDesignBody::activated(int iMsg)
     // first check if Part is already created:
     App::Part *actPart =  getDocument()->Tip.getValue<App::Part *>();
     std::string PartName;
-    
+
     if(!actPart){
         // if not, creating a part and set it up by calling the appropiated function in Workbench
         //if we create a new part we automaticly get a new body, there is no need to create a second one
@@ -402,7 +402,7 @@ void CmdPartDesignMoveFeature::activated(int iMsg)
             App::DocumentObject* prevSolidFeature = target->getPrevSolidFeature();
             doCommand(Gui,"Gui.activeDocument().hide(\"%s\")", prevSolidFeature->getNameInDocument());
             doCommand(Gui,"Gui.activeDocument().show(\"%s\")", (*f)->getNameInDocument());
-        }  
+        }
     }
 }
 
@@ -564,9 +564,9 @@ const QString getReferenceString(Gui::Command* cmd)
                     QString::fromAscii(",'')]");
         }
     }
-    
-    //datum features task can start without reference, as every needed one can be set from 
-    //withing the task. 
+
+    //datum features task can start without reference, as every needed one can be set from
+    //withing the task.
     return QString::fromAscii("");
 }
 
@@ -746,12 +746,12 @@ void CmdPartDesignNewSketch::activated(int iMsg)
 
         if (FaceFilter.match()) {
             obj = FaceFilter.Result[0][0].getObject();
-            
+
             if(!obj->isDerivedFrom(Part::Feature::getClassTypeId()))
                 return;
-            
+
             Part::Feature* feat = static_cast<Part::Feature*>(obj);
-            
+
             // FIXME: Reject or warn about feature that is outside of active body, and feature
             // that comes after the current insert point (Tip)
             const std::vector<std::string> &sub = FaceFilter.Result[0][0].getSubNames();
@@ -812,7 +812,7 @@ void CmdPartDesignNewSketch::activated(int iMsg)
         std::string FeatName = getUniqueObjectName("Sketch");
 
         openCommand("Create a Sketch on Face");
-        doCommand(Doc,"App.activeDocument().addObject('Sketcher::SketchObject','%s')",FeatName.c_str());        
+        doCommand(Doc,"App.activeDocument().addObject('Sketcher::SketchObject','%s')",FeatName.c_str());
         doCommand(Doc,"App.activeDocument().%s.Support = %s",FeatName.c_str(),supportString.c_str());
         doCommand(Doc,"App.activeDocument().%s.addFeature(App.activeDocument().%s)",
                        pcActiveBody->getNameInDocument(), FeatName.c_str());
@@ -873,15 +873,15 @@ void CmdPartDesignNewSketch::activated(int iMsg)
         }
 
         auto accepter = [=](const std::vector<App::DocumentObject*>& features) -> bool {
-            
+
             if(features.empty())
                 return false;
-                            
+
             return true;
         };
-        
+
         auto worker = [=](const std::vector<App::DocumentObject*>& features) {
-            App::Plane* plane = static_cast<App::Plane*>(features.front());        
+            App::Plane* plane = static_cast<App::Plane*>(features.front());
             std::string FeatName = getUniqueObjectName("Sketch");
             std::string supportString = std::string("(App.activeDocument().") + plane->getNameInDocument() +
                                         ", ['" + (false ? "back" : "front") + "'])";
@@ -895,11 +895,11 @@ void CmdPartDesignNewSketch::activated(int iMsg)
             //doCommand(Gui,"Gui.activeDocument().activeView().setCamera('%s')",cam.c_str());
             Gui::Command::doCommand(Gui,"Gui.activeDocument().setEdit('%s')",FeatName.c_str());
         };
-           
+
         // If there is more than one possibility, show dialog and let user pick plane
         bool reversed = false;
         if (validPlanes > 1) {
-        
+
            Gui::TaskView::TaskDialog *dlg = Gui::Control().activeDialog();
            PartDesignGui::TaskDlgFeaturePick *pickDlg = qobject_cast<PartDesignGui::TaskDlgFeaturePick *>(dlg);
            if (dlg && !pickDlg) {
@@ -914,7 +914,7 @@ void CmdPartDesignNewSketch::activated(int iMsg)
                 else
                     return;
             }
-            
+
             if(dlg)
                 Gui::Control().closeDialog();
 
@@ -975,7 +975,7 @@ void finishFeature(const Gui::Command* cmd, const std::string& FeatName, const b
  const unsigned validateSketches(std::vector<App::DocumentObject*>& sketches,
                                  std::vector<PartDesignGui::TaskFeaturePick::featureStatus>& status,
                                  std::vector<App::DocumentObject*>::iterator& firstValidSketch)
-{    
+{
     // TODO: If the user previously opted to allow multiple use of sketches or use of sketches from other bodies,
     // then count these as valid sketches!
     unsigned validSketches = 0;
@@ -1035,7 +1035,7 @@ void finishFeature(const Gui::Command* cmd, const std::string& FeatName, const b
     return validSketches;
 }
 
-void prepareSketchBased(Gui::Command* cmd, const std::string& which, 
+void prepareSketchBased(Gui::Command* cmd, const std::string& which,
                         boost::function<void (Part::Part2DObject*, std::string)> func)
 {
     PartDesign::Body *pcActiveBody = PartDesignGui::getBody(/*messageIfNot = */true);
@@ -1046,7 +1046,7 @@ void prepareSketchBased(Gui::Command* cmd, const std::string& which,
     std::vector<PartDesignGui::TaskFeaturePick::featureStatus> status;
     std::vector<App::DocumentObject*>::iterator firstValidSketch;
     std::vector<App::DocumentObject*> sketches = cmd->getSelection().getObjectsOfType(Part::Part2DObject::getClassTypeId());
-    // Next let the user choose from a list of all eligible objects    
+    // Next let the user choose from a list of all eligible objects
     unsigned validSketches = validateSketches(sketches, status, firstValidSketch);
     if (validSketches == 0) {
         status.clear();
@@ -1058,17 +1058,17 @@ void prepareSketchBased(Gui::Command* cmd, const std::string& which,
             return;
         }
     }
-    
+
     auto accepter = [=](const std::vector<App::DocumentObject*>& features) -> bool {
-        
+
         if(features.empty())
             return false;
-                        
+
         return true;
     };
-    
+
     auto worker = [which, cmd, func](std::vector<App::DocumentObject*> features) {
-        
+
         auto firstValidSketch = features.begin();
         Part::Part2DObject* sketch = static_cast<Part::Part2DObject*>(*firstValidSketch);
 
@@ -1079,13 +1079,13 @@ void prepareSketchBased(Gui::Command* cmd, const std::string& which,
                     which.c_str(), FeatName.c_str());
         Gui::Command::doCommand(Gui::Command::Doc,"App.activeDocument().%s.Sketch = App.activeDocument().%s",
                     FeatName.c_str(), sketch->getNameInDocument());
-        
+
         func(sketch, FeatName);
     };
-    
+
     // If there is more than one selection/possibility, show dialog and let user pick sketch
     if (validSketches > 1) {
-        
+
         Gui::TaskView::TaskDialog *dlg = Gui::Control().activeDialog();
         PartDesignGui::TaskDlgFeaturePick *pickDlg = qobject_cast<PartDesignGui::TaskDlgFeaturePick *>(dlg);
         if (dlg && !pickDlg) {
@@ -1100,7 +1100,7 @@ void prepareSketchBased(Gui::Command* cmd, const std::string& which,
             else
                 return;
         }
-        
+
         if(dlg)
             Gui::Control().closeDialog();
 
@@ -1110,7 +1110,7 @@ void prepareSketchBased(Gui::Command* cmd, const std::string& which,
     else {
         worker(sketches);
     }
-    
+
 }
 
 void finishSketchBased(const Gui::Command* cmd, const Part::Part2DObject* sketch, const std::string& FeatName)
@@ -1137,12 +1137,12 @@ CmdPartDesignPad::CmdPartDesignPad()
 }
 
 void CmdPartDesignPad::activated(int iMsg)
-{          
+{
     Gui::Command* cmd = this;
     auto worker = [cmd](Part::Part2DObject* sketch, std::string FeatName) {
-        
+
         if (FeatName.empty()) return;
-        
+
         // specific parameters for Pad
         Gui::Command::doCommand(Doc,"App.activeDocument().%s.Length = 10.0",FeatName.c_str());
         App::DocumentObjectGroup* grp = sketch->getGroup();
@@ -1157,7 +1157,7 @@ void CmdPartDesignPad::activated(int iMsg)
         finishSketchBased(cmd, sketch, FeatName);
         cmd->adjustCameraPosition();
     };
-    
+
     prepareSketchBased(this, "Pad", worker);
 }
 
@@ -1187,14 +1187,14 @@ void CmdPartDesignPocket::activated(int iMsg)
 {
     Gui::Command* cmd = this;
     auto worker = [cmd](Part::Part2DObject* sketch, std::string FeatName) {
-        
+
         if (FeatName.empty()) return;
-        
+
         Gui::Command::doCommand(Doc,"App.activeDocument().%s.Length = 5.0",FeatName.c_str());
         finishSketchBased(cmd, sketch, FeatName);
         cmd->adjustCameraPosition();
     };
-    
+
     prepareSketchBased(this, "Pocket", worker);
 }
 
@@ -1224,7 +1224,7 @@ void CmdPartDesignRevolution::activated(int iMsg)
 {
     Gui::Command* cmd = this;
     auto worker = [cmd](Part::Part2DObject* sketch, std::string FeatName) {
-        
+
         if (FeatName.empty()) return;
 
         Gui::Command::doCommand(Doc,"App.activeDocument().%s.ReferenceAxis = (App.activeDocument().%s,['V_Axis'])",
@@ -1233,11 +1233,11 @@ void CmdPartDesignRevolution::activated(int iMsg)
         PartDesign::Revolution* pcRevolution = static_cast<PartDesign::Revolution*>(cmd->getDocument()->getObject(FeatName.c_str()));
         if (pcRevolution && pcRevolution->suggestReversed())
             Gui::Command::doCommand(Doc,"App.activeDocument().%s.Reversed = 1",FeatName.c_str());
-    
+
         finishSketchBased(cmd, sketch, FeatName);
         cmd->adjustCameraPosition();
     };
-    
+
     prepareSketchBased(this, "Revolution", worker);
 }
 
@@ -1264,10 +1264,10 @@ CmdPartDesignGroove::CmdPartDesignGroove()
 }
 
 void CmdPartDesignGroove::activated(int iMsg)
-{   
+{
     Gui::Command* cmd = this;
     auto worker = [cmd](Part::Part2DObject* sketch, std::string FeatName) {
-        
+
         if (FeatName.empty()) return;
 
         Gui::Command::doCommand(Doc,"App.activeDocument().%s.ReferenceAxis = (App.activeDocument().%s,['V_Axis'])",
@@ -1276,11 +1276,11 @@ void CmdPartDesignGroove::activated(int iMsg)
         PartDesign::Groove* pcGroove = static_cast<PartDesign::Groove*>(cmd->getDocument()->getObject(FeatName.c_str()));
         if (pcGroove && pcGroove->suggestReversed())
             Gui::Command::doCommand(Doc,"App.activeDocument().%s.Reversed = 1",FeatName.c_str());
-    
+
         finishSketchBased(cmd, sketch, FeatName);
         cmd->adjustCameraPosition();
     };
-    
+
     prepareSketchBased(this, "Groove", worker);
 }
 
@@ -1307,19 +1307,19 @@ CmdPartDesignAdditivePipe::CmdPartDesignAdditivePipe()
 }
 
 void CmdPartDesignAdditivePipe::activated(int iMsg)
-{          
+{
     Gui::Command* cmd = this;
     auto worker = [cmd](Part::Part2DObject* sketch, std::string FeatName) {
-        
+
         if (FeatName.empty()) return;
-        
+
         // specific parameters for pipe
         Gui::Command::updateActive();
 
         finishSketchBased(cmd, sketch, FeatName);
         cmd->adjustCameraPosition();
     };
-    
+
     prepareSketchBased(this, "AdditivePipe", worker);
 }
 
@@ -1347,19 +1347,19 @@ CmdPartDesignSubtractivePipe::CmdPartDesignSubtractivePipe()
 }
 
 void CmdPartDesignSubtractivePipe::activated(int iMsg)
-{          
+{
     Gui::Command* cmd = this;
     auto worker = [cmd](Part::Part2DObject* sketch, std::string FeatName) {
-        
+
         if (FeatName.empty()) return;
-        
+
         // specific parameters for pipe
         Gui::Command::updateActive();
 
         finishSketchBased(cmd, sketch, FeatName);
         cmd->adjustCameraPosition();
     };
-    
+
     prepareSketchBased(this, "SubtractivePipe", worker);
 }
 
@@ -1385,7 +1385,7 @@ void makeChamferOrFillet(Gui::Command* cmd, const std::string& which)
             QObject::tr("Select an edge, face or body. Only one body is allowed."));
         return;
     }
-    
+
     Gui::Selection().clearSelection();
 
     if (!selection[0].isObjectTypeOf(Part::Feature::getClassTypeId())){
@@ -1709,19 +1709,19 @@ bool CmdPartDesignThickness::isActive(void)
 // Common functions for all Transformed features
 //===========================================================================
 
-void prepareTransformed(Gui::Command* cmd, const std::string& which, 
+void prepareTransformed(Gui::Command* cmd, const std::string& which,
                         boost::function<void(std::string, std::vector<App::DocumentObject*>)> func)
 {
     std::string FeatName = cmd->getUniqueObjectName(which.c_str());
 
     auto accepter = [=](std::vector<App::DocumentObject*> features) -> bool{
-        
+
         if(features.empty())
             return false;
-        
+
         return true;
     };
-        
+
     auto worker = [=](std::vector<App::DocumentObject*> features) {
         std::stringstream str;
         str << "App.activeDocument()." << FeatName << ".Originals = [";
@@ -1736,10 +1736,10 @@ void prepareTransformed(Gui::Command* cmd, const std::string& which,
         // Exception (Thu Sep  6 11:52:01 2012): 'App.Document' object has no attribute 'Mirrored'
         Gui::Command::updateActive(); // Helps to ensure that the object already exists when the next command comes up
         Gui::Command::doCommand(Gui::Command::Doc, str.str().c_str());
-        
+
         func(FeatName, features);
     };
-    
+
     // Get a valid original from the user
     // First check selections
     std::vector<App::DocumentObject*> features = cmd->getSelection().getObjectsOfType(PartDesign::FeatureAddSub::getClassTypeId());
@@ -1751,7 +1751,7 @@ void prepareTransformed(Gui::Command* cmd, const std::string& which,
             std::vector<PartDesignGui::TaskFeaturePick::featureStatus> status;
             for (unsigned i = 0; i < features.size(); i++)
                 status.push_back(PartDesignGui::TaskFeaturePick::validFeature);
-            
+
             Gui::TaskView::TaskDialog *dlg = Gui::Control().activeDialog();
             PartDesignGui::TaskDlgFeaturePick *pickDlg = qobject_cast<PartDesignGui::TaskDlgFeaturePick *>(dlg);
             if (dlg && !pickDlg) {
@@ -1766,7 +1766,7 @@ void prepareTransformed(Gui::Command* cmd, const std::string& which,
                 else
                     return;
             }
-            
+
             if(dlg)
                 Gui::Control().closeDialog();
 
@@ -1809,10 +1809,10 @@ void CmdPartDesignMirrored::activated(int iMsg)
 {
     Gui::Command* cmd = this;
     auto worker = [cmd](std::string FeatName, std::vector<App::DocumentObject*> features) {
-        
+
         if (features.empty())
         return;
-        
+
         if(features.front()->isDerivedFrom(PartDesign::SketchBased::getClassTypeId())) {
             Part::Part2DObject *sketch = (static_cast<PartDesign::SketchBased*>(features.front()))->getVerifiedSketch();
             if (sketch)
@@ -1826,8 +1826,8 @@ void CmdPartDesignMirrored::activated(int iMsg)
 
         finishTransformed(cmd, FeatName);
     };
-    
-    prepareTransformed(this, "Mirrored", worker);    
+
+    prepareTransformed(this, "Mirrored", worker);
 }
 
 bool CmdPartDesignMirrored::isActive(void)
@@ -1856,7 +1856,7 @@ void CmdPartDesignLinearPattern::activated(int iMsg)
 {
     Gui::Command* cmd = this;
     auto worker = [cmd](std::string FeatName, std::vector<App::DocumentObject*> features) {
-        
+
         if (features.empty())
             return;
 
@@ -1875,8 +1875,8 @@ void CmdPartDesignLinearPattern::activated(int iMsg)
 
         finishTransformed(cmd, FeatName);
     };
-    
-    prepareTransformed(this, "LinearPattern", worker); 
+
+    prepareTransformed(this, "LinearPattern", worker);
 }
 
 bool CmdPartDesignLinearPattern::isActive(void)
@@ -1902,13 +1902,13 @@ CmdPartDesignPolarPattern::CmdPartDesignPolarPattern()
 }
 
 void CmdPartDesignPolarPattern::activated(int iMsg)
-{    
+{
     Gui::Command* cmd = this;
     auto worker = [cmd](std::string FeatName, std::vector<App::DocumentObject*> features) {
-        
+
         if (features.empty())
             return;
-        
+
         if(features.front()->isDerivedFrom(PartDesign::SketchBased::getClassTypeId())) {
             Part::Part2DObject *sketch = (static_cast<PartDesign::SketchBased*>(features.front()))->getVerifiedSketch();
             if (sketch)
@@ -1919,15 +1919,15 @@ void CmdPartDesignPolarPattern::activated(int iMsg)
             doCommand(Doc,"App.activeDocument().%s.Axis = (App.activeDocument().%s, [\"\"])", FeatName.c_str(),
                       App::Part::BaselineTypes[0]);
         }
-        
+
         doCommand(Doc,"App.activeDocument().%s.Angle = 360", FeatName.c_str());
         doCommand(Doc,"App.activeDocument().%s.Occurrences = 2", FeatName.c_str());
 
         finishTransformed(cmd, FeatName);
     };
-    
-    prepareTransformed(this, "PolarPattern", worker); 
-    
+
+    prepareTransformed(this, "PolarPattern", worker);
+
 }
 
 bool CmdPartDesignPolarPattern::isActive(void)
@@ -1953,20 +1953,20 @@ CmdPartDesignScaled::CmdPartDesignScaled()
 }
 
 void CmdPartDesignScaled::activated(int iMsg)
-{    
+{
     Gui::Command* cmd = this;
     auto worker = [cmd](std::string FeatName, std::vector<App::DocumentObject*> features) {
-        
+
         if (features.empty())
         return;
-        
+
         doCommand(Doc,"App.activeDocument().%s.Factor = 2", FeatName.c_str());
         doCommand(Doc,"App.activeDocument().%s.Occurrences = 2", FeatName.c_str());
 
         finishTransformed(cmd, FeatName);
     };
-    
-    prepareTransformed(this, "Scaled", worker);    
+
+    prepareTransformed(this, "Scaled", worker);
 }
 
 bool CmdPartDesignScaled::isActive(void)
@@ -2044,13 +2044,13 @@ void CmdPartDesignMultiTransform::activated(int iMsg)
             Gui::Selection().clearSelection();
         } // otherwise the insert point remains at the new MultiTransform, which is fine
     } else {
-        
+
         Gui::Command* cmd = this;
         auto worker = [cmd, pcActiveBody](std::string FeatName, std::vector<App::DocumentObject*> features) {
-            
+
             if (features.empty())
                 return;
-            
+
             // Make sure the user isn't presented with an empty screen because no transformations are defined yet...
             App::DocumentObject* prevSolid = pcActiveBody->getPrevSolidFeature(NULL, true);
             if (prevSolid != NULL) {
@@ -2060,8 +2060,8 @@ void CmdPartDesignMultiTransform::activated(int iMsg)
             }
             finishFeature(cmd, FeatName);
         };
-        
-        prepareTransformed(this, "MultiTransform", worker);   
+
+        prepareTransformed(this, "MultiTransform", worker);
     }
 }
 
@@ -2115,9 +2115,9 @@ void CmdPartDesignBoolean::activated(int iMsg)
 
     openCommand("Create Boolean");
 
-	PartDesign::Body* activeBody = Gui::Application::Instance->activeView()->getActiveObject<PartDesign::Body*>(PDBODYKEY);
+    PartDesign::Body* activeBody = Gui::Application::Instance->activeView()->getActiveObject<PartDesign::Body*>(PDBODYKEY);
     // Make sure we are working on the selected body
-	if (body != activeBody) {
+    if (body != activeBody) {
         Gui::Selection().clearSelection();
         Gui::Selection().addSelection(body->getDocument()->getName(), body->Tip.getValue()->getNameInDocument());
         Gui::Command::doCommand(Gui::Command::Gui,"FreeCADGui.runCommand('PartDesign_MoveTip')");
@@ -2168,9 +2168,9 @@ void CreatePartDesignCommands(void)
     rcCmdMgr.addCommand(new CmdPartDesignGroove());
 
     rcCmdMgr.addCommand(new CmdPartDesignFillet());
-    rcCmdMgr.addCommand(new CmdPartDesignDraft());    
+    rcCmdMgr.addCommand(new CmdPartDesignDraft());
     rcCmdMgr.addCommand(new CmdPartDesignChamfer());
-    rcCmdMgr.addCommand(new CmdPartDesignThickness());    
+    rcCmdMgr.addCommand(new CmdPartDesignThickness());
 
     rcCmdMgr.addCommand(new CmdPartDesignMirrored());
     rcCmdMgr.addCommand(new CmdPartDesignLinearPattern());

--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -402,6 +402,15 @@ void CmdPartDesignMoveFeature::activated(int iMsg)
             App::DocumentObject* prevSolidFeature = target->getPrevSolidFeature();
             doCommand(Gui,"Gui.activeDocument().hide(\"%s\")", prevSolidFeature->getNameInDocument());
             doCommand(Gui,"Gui.activeDocument().show(\"%s\")", (*f)->getNameInDocument());
+        } else if ((*f)->getTypeId().isDerivedFrom(Sketcher::SketchObject::getClassTypeId())) {
+            Sketcher::SketchObject *sketch = static_cast<Sketcher::SketchObject*>(*f);
+            try {
+                PartDesignGui::Workbench::fixSketchSupport(sketch);
+            } catch (Base::Exception &) {
+                QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Sketch plane cannot be migrated"),
+                        QObject::tr("Please edit '%1' and redefine it to use a Base or Datum plane as the sketch plane.").
+                        arg(QString::fromAscii(sketch->getNameInDocument()) ) );
+            }
         }
     }
 }

--- a/src/Mod/PartDesign/Gui/Workbench.cpp
+++ b/src/Mod/PartDesign/Gui/Workbench.cpp
@@ -265,8 +265,8 @@ void Workbench::_doMigration(const App::Document* doc)
                     features.erase(feat);
                 } else {
                     QMessageBox::critical(Gui::getMainWindow(), QObject::tr("Non-linear tree"),
-                        QObject::tr("Please look at '") + QString::fromAscii((*o)->getNameInDocument()) +
-                        QObject::tr("' and make sure that the migration result is what you would expect."));
+                        QObject::tr("Please look at '%1' and make sure that the migration result is what you"
+                                    " would expect.").arg(QString::fromAscii((*o)->getNameInDocument())));
                 }
             }
             std::set<App::DocumentObject*> newInList;

--- a/src/Mod/PartDesign/Gui/Workbench.cpp
+++ b/src/Mod/PartDesign/Gui/Workbench.cpp
@@ -312,75 +312,13 @@ void Workbench::_doMigration(const App::Document* doc)
 
         for (std::vector<App::DocumentObject*>::const_iterator f = bodyFeatures.begin(); f != bodyFeatures.end(); f++) {
             if ((*f)->getTypeId().isDerivedFrom(Sketcher::SketchObject::getClassTypeId())) {
-                Sketcher::SketchObject* sketch = static_cast<Sketcher::SketchObject*>(*f);
-                App::DocumentObject* support = sketch->Support.getValue();
-                if (support != NULL)
-                    continue; // Sketch is on a face of a solid
-                Base::Placement plm = sketch->Placement.getValue();
-                Base::Vector3d pnt = plm.getPosition();
-
-                // Currently we only handle positions that are parallel to the base planes
-                Base::Rotation rot = plm.getRotation();
-                Base::Vector3d SketchVector(0,0,1);
-                rot.multVec(SketchVector, SketchVector);
-                std::string  side = (SketchVector.x + SketchVector.y + SketchVector.z) < 0.0 ? "back" : "front";
-                if (side == "back") SketchVector *= -1.0;
-                int index;
-
-                if (SketchVector == Base::Vector3d(0,0,1))
-                    index = 0;
-                else if (SketchVector == Base::Vector3d(0,1,0))
-                    index = 1;
-                else if (SketchVector == Base::Vector3d(1,0,0))
-                    index = 2;
-                else {
+                Sketcher::SketchObject *sketch = static_cast<Sketcher::SketchObject*>(*f);
+                try {
+                    fixSketchSupport(sketch);
+                } catch (Base::Exception &) {
                     QMessageBox::critical(Gui::getMainWindow(), QObject::tr("Sketch plane cannot be migrated"),
-                        QObject::tr("Please edit '") + QString::fromAscii(sketch->getNameInDocument()) +
-                        QObject::tr("' and redefine it to use a Base or Datum plane as the sketch plane."));
-                    continue;
-                }
-
-                // Find the normal distance from origin to the sketch plane
-                gp_Pln pln(gp_Pnt (pnt.x, pnt.y, pnt.z), gp_Dir(SketchVector.x, SketchVector.y, SketchVector.z));
-                double offset = pln.Distance(gp_Pnt(0,0,0));
-
-                if (fabs(offset) < Precision::Confusion()) {
-                    // One of the base planes
-                    Gui::Command::doCommand(Gui::Command::Doc,"App.activeDocument().%s.Support = (App.activeDocument().%s,['%s'])",
-                                            sketch->getNameInDocument(), App::Part::BaseplaneTypes[index], side.c_str());
-                } else {
-                    // Offset to base plane
-                    // Find out which direction we need to offset
-                    double a = SketchVector.GetAngle(pnt);
-                    if ((a < -M_PI_2) || (a > M_PI_2))
-                        offset *= -1.0;
-
-                    // Insert a new datum plane before the sketch
-                    App::DocumentObject* oldTip = activeBody->Tip.getValue();
-                    Gui::Selection().clearSelection();
-                    if (f != bodyFeatures.begin())
-                        Gui::Selection().addSelection(doc->getName(), (*prevf)->getNameInDocument());
-                    Gui::Command::doCommand(Gui::Command::Gui,"FreeCADGui.runCommand('PartDesign_MoveTip')");
-
-                    std::string Datum = doc->getUniqueObjectName("DatumPlane");
-                    Gui::Command::doCommand(Gui::Command::Doc,"App.activeDocument().addObject('PartDesign::Plane','%s')",Datum.c_str());
-                    QString refStr = QString::fromAscii("[(App.activeDocument().") + QString::fromAscii(App::Part::BaseplaneTypes[index]) +
-                                     QString::fromAscii(",'')]");
-                    Gui::Command::doCommand(Gui::Command::Doc,"App.activeDocument().%s.References = %s",Datum.c_str(), refStr.toStdString().c_str());
-                    Gui::Command::doCommand(Gui::Command::Doc,"App.activeDocument().%s.Offset = %f",Datum.c_str(), offset);
-                    Gui::Command::doCommand(Gui::Command::Doc,"App.activeDocument().%s.Angle = 0.0",Datum.c_str());
-                    Gui::Command::doCommand(Gui::Command::Doc,"App.activeDocument().%s.addFeature(App.activeDocument().%s)",
-                                   activeBody->getNameInDocument(), Datum.c_str());
-                    Gui::Command::doCommand(Gui::Command::Doc,"App.activeDocument().%s.Support = (App.activeDocument().%s,['%s'])",
-                                            sketch->getNameInDocument(), Datum.c_str(), side.c_str());
-                    Gui::Command::doCommand(Gui::Command::Gui,"App.activeDocument().recompute()");  // recompute the feature based on its references
-
-                    Gui::Selection().clearSelection();
-                    if (oldTip != NULL) {
-                        Gui::Selection().addSelection(doc->getName(), oldTip->getNameInDocument());
-                        Gui::Command::doCommand(Gui::Command::Gui,"FreeCADGui.runCommand('PartDesign_MoveTip')");
-                        Gui::Selection().clearSelection();
-                    }
+                        QObject::tr("Please edit '%1' and redefine it to use a Base or Datum plane as the sketch plane.").
+                            arg(QString::fromAscii(sketch->getNameInDocument()) ) );
                 }
             }
 
@@ -389,6 +327,74 @@ void Workbench::_doMigration(const App::Document* doc)
     }
 
 }
+
+
+void Workbench::fixSketchSupport (Sketcher::SketchObject* sketch) 
+{
+    App::DocumentObject* support = sketch->Support.getValue();
+    
+    if (support)
+        return; // Sketch is on a face of a solid, do nothing
+
+    const App::Document* doc = sketch->getDocument();
+    PartDesign::Body *body = getBodyFor(sketch, /*messageIfNot*/ 0);
+
+    if (!body) {
+        throw Base::Exception ("Coudn't find body for the sketch");
+    }
+
+    Base::Placement plm = sketch->Placement.getValue();
+    Base::Vector3d pnt = plm.getPosition();
+
+    // Currently we only handle positions that are parallel to the base planes
+    Base::Rotation rot = plm.getRotation();
+    Base::Vector3d sketchVector(0,0,1);
+    rot.multVec(sketchVector, sketchVector);
+    std::string  side = (sketchVector.x + sketchVector.y + sketchVector.z) < 0.0 ? "back" : "front";
+    if (side == "back") sketchVector *= -1.0;
+    int index;
+
+    if (sketchVector == Base::Vector3d(0,0,1))
+        index = 0;
+    else if (sketchVector == Base::Vector3d(0,1,0))
+        index = 1;
+    else if (sketchVector == Base::Vector3d(1,0,0))
+        index = 2;
+    else {
+        throw Base::Exception("Sketch plane cannot be migrated");
+    }
+
+    // Find the normal distance from origin to the sketch plane
+    gp_Pln pln(gp_Pnt (pnt.x, pnt.y, pnt.z), gp_Dir(sketchVector.x, sketchVector.y, sketchVector.z));
+    double offset = pln.Distance(gp_Pnt(0,0,0));
+
+    if (fabs(offset) < Precision::Confusion()) {
+        // One of the base planes
+        Gui::Command::doCommand(Gui::Command::Doc,"App.activeDocument().%s.Support = (App.activeDocument().%s,['%s'])",
+                sketch->getNameInDocument(), App::Part::BaseplaneTypes[index], side.c_str());
+    } else {
+        // Offset to base plane
+        // Find out which direction we need to offset
+        double a = sketchVector.GetAngle(pnt);
+        if ((a < -M_PI_2) || (a > M_PI_2))
+            offset *= -1.0;
+
+        std::string Datum = doc->getUniqueObjectName("DatumPlane");
+        Gui::Command::doCommand(Gui::Command::Doc,"App.activeDocument().addObject('PartDesign::Plane','%s')",Datum.c_str());
+        QString refStr = QString::fromAscii("[(App.activeDocument().") + QString::fromAscii(App::Part::BaseplaneTypes[index]) +
+            QString::fromAscii(",'')]");
+        Gui::Command::doCommand(Gui::Command::Doc,"App.activeDocument().%s.References = %s",Datum.c_str(), refStr.toStdString().c_str());
+        Gui::Command::doCommand(Gui::Command::Doc,"App.activeDocument().%s.Offset = %f",Datum.c_str(), offset);
+        Gui::Command::doCommand(Gui::Command::Doc,"App.activeDocument().%s.Angle = 0.0",Datum.c_str());
+        Gui::Command::doCommand(Gui::Command::Doc,
+                "App.activeDocument().%s.insertFeatureBefore(App.activeDocument().%s, App.activeDocument().%s)",
+                body->getNameInDocument(), Datum.c_str(), sketch->getNameInDocument());
+        Gui::Command::doCommand(Gui::Command::Doc,"App.activeDocument().%s.Support = (App.activeDocument().%s,['%s'])",
+                sketch->getNameInDocument(), Datum.c_str(), side.c_str());
+        Gui::Command::doCommand(Gui::Command::Gui,"App.activeDocument().recompute()");  // recompute the feature based on its references
+    }
+}
+
 
 void Workbench::_switchToDocument(const App::Document* doc)
 {

--- a/src/Mod/PartDesign/Gui/Workbench.cpp
+++ b/src/Mod/PartDesign/Gui/Workbench.cpp
@@ -79,7 +79,7 @@ PartDesign::Body *getBody(bool messageIfNot)
     if (!activeBody && messageIfNot){
         QMessageBox::warning(Gui::getMainWindow(), QObject::tr("No active Body"),
             QObject::tr("In order to use PartDesign you need an active Body object in the document. "
-			"Please make one active (double click) or create one. If you have a legacy document "
+                        "Please make one active (double click) or create one. If you have a legacy document "
                         "with PartDesign objects without Body, use the transfer function in "
                         "PartDesign to put them into a Body."
                         ));
@@ -92,7 +92,7 @@ PartDesign::Body *getBodyFor(App::DocumentObject* obj, bool messageIfNot)
 {
     if(!obj)
         return nullptr;
-    
+
     PartDesign::Body * activeBody = Gui::Application::Instance->activeView()->getActiveObject<PartDesign::Body*>(PDBODYKEY);
     if(activeBody && activeBody->hasFeature(obj))
         return activeBody;
@@ -101,14 +101,14 @@ PartDesign::Body *getBodyFor(App::DocumentObject* obj, bool messageIfNot)
     for(PartDesign::Body* b : obj->getDocument()->getObjectsOfType<PartDesign::Body>()) {
         if(b->isFeature(obj)) {
             return b;
-        }            
+        }
     }
-        
+
     if (messageIfNot){
         QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Feature is not in a body"),
             QObject::tr("In order to use this feature it needs to belong to a body object in the document."));
     }
-    
+
     return nullptr;
 }
 
@@ -116,23 +116,23 @@ App::Part* getPartFor(App::DocumentObject* obj, bool messageIfNot) {
 
     if(!obj)
         return nullptr;
-    
+
     PartDesign::Body* body = getBodyFor(obj, false);
     if(body)
         obj = body;
-    
+
     //get the part every body should belong to
     for(App::Part* p : obj->getDocument()->getObjectsOfType<App::Part>()) {
         if(p->hasObject(obj)) {
             return p;
-        }            
+        }
     }
-    
+
     if (messageIfNot){
         QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Feature is not in a part"),
             QObject::tr("In order to use this feature it needs to belong to a part object in the document."));
     }
-    
+
     return nullptr;
 }
 
@@ -163,33 +163,33 @@ static void buildDefaultPartAndBody(const App::Document* doc)
 
 PartDesign::Body *Workbench::setUpPart(const App::Part *part)
 {
-	// first do the general Part setup
-	Gui::ViewProviderPart::setUpPart(part);
+    // first do the general Part setup
+    Gui::ViewProviderPart::setUpPart(part);
 
-	// check for Bodies
-	std::vector<App::DocumentObject*> bodies = part->getObjectsOfType(PartDesign::Body::getClassTypeId());
-	assert(bodies.size() == 0);
-	
-	std::string PartName = part->getNameInDocument();
-	std::string BodyName = part->getDocument()->getUniqueObjectName("MainBody");
+    // check for Bodies
+    std::vector<App::DocumentObject*> bodies = part->getObjectsOfType(PartDesign::Body::getClassTypeId());
+    assert(bodies.size() == 0);
 
-	Gui::Command::addModule(Gui::Command::Doc, "PartDesign");
-	Gui::Command::doCommand(Gui::Command::Doc, "App.activeDocument().addObject('PartDesign::Body','%s')", BodyName.c_str());
-	Gui::Command::doCommand(Gui::Command::Doc, "App.activeDocument().%s.addObject(App.activeDocument().ActiveObject)", part->getNameInDocument());
-	Gui::Command::doCommand(Gui::Command::Gui, "Gui.activeView().setActiveObject('%s', App.activeDocument().%s)", PDBODYKEY, BodyName.c_str());
-        Gui::Command::updateActive();
+    std::string PartName = part->getNameInDocument();
+    std::string BodyName = part->getDocument()->getUniqueObjectName("MainBody");
 
-	return NULL;
+    Gui::Command::addModule(Gui::Command::Doc, "PartDesign");
+    Gui::Command::doCommand(Gui::Command::Doc, "App.activeDocument().addObject('PartDesign::Body','%s')", BodyName.c_str());
+    Gui::Command::doCommand(Gui::Command::Doc, "App.activeDocument().%s.addObject(App.activeDocument().ActiveObject)", part->getNameInDocument());
+    Gui::Command::doCommand(Gui::Command::Gui, "Gui.activeView().setActiveObject('%s', App.activeDocument().%s)", PDBODYKEY, BodyName.c_str());
+    Gui::Command::updateActive();
+
+    return NULL;
 }
 
 void Workbench::_doMigration(const App::Document* doc)
 {
-	bool groupCreated = false;
+    bool groupCreated = false;
 
     if(doc->countObjects() != 0) {
          // show a warning about the convertion
          Gui::Dialog::DlgCheckableMessageBox::showMessage(
-            QString::fromLatin1("PartDesign conversion warning"), 
+            QString::fromLatin1("PartDesign conversion warning"),
             QString::fromLatin1(
             "<h2>Converting PartDesign features to new Body centric schema</h2>"
             "If you are unsure what that mean save the document under a new name.<br>"
@@ -208,7 +208,7 @@ void Workbench::_doMigration(const App::Document* doc)
     Gui::Command::openCommand("Migrate part to Body feature");
 
     // Get the objects now, before adding the Body and the base planes
-    std::vector<App::DocumentObject*> features = doc->getObjects();        
+    std::vector<App::DocumentObject*> features = doc->getObjects();
 
     // Assign all non-PartDesign features to a new group
     for (std::vector<App::DocumentObject*>::iterator f = features.begin(); f != features.end(); ) {
@@ -249,7 +249,7 @@ void Workbench::_doMigration(const App::Document* doc)
     for (std::vector<App::DocumentObject*>::iterator r = roots.begin(); r != roots.end(); r++) {
         if (r != roots.begin()) {
             Gui::Command::runCommand(Gui::Command::Doc, "FreeCADGui.runCommand('PartDesign_Body')");
-			activeBody = Gui::Application::Instance->activeView()->getActiveObject<PartDesign::Body*>(PDBODYKEY);
+            activeBody = Gui::Application::Instance->activeView()->getActiveObject<PartDesign::Body*>(PDBODYKEY);
         }
 
         std::set<App::DocumentObject*> inList;
@@ -329,10 +329,10 @@ void Workbench::_doMigration(const App::Document* doc)
 }
 
 
-void Workbench::fixSketchSupport (Sketcher::SketchObject* sketch) 
+void Workbench::fixSketchSupport (Sketcher::SketchObject* sketch)
 {
     App::DocumentObject* support = sketch->Support.getValue();
-    
+
     if (support)
         return; // Sketch is on a face of a solid, do nothing
 
@@ -401,27 +401,26 @@ void Workbench::_switchToDocument(const App::Document* doc)
     bool groupCreated = false;
 
 
-    if (doc == NULL) return;        
+    if (doc == NULL) return;
 
     PartDesign::Body* activeBody = NULL;
     std::vector<App::DocumentObject*> bodies = doc->getObjectsOfType(PartDesign::Body::getClassTypeId());
 
     // No tip, so build up structure or migrate
-	if (!doc->Tip.getValue())
+    if (!doc->Tip.getValue())
     {
-		if (doc->countObjects() == 0){
-			buildDefaultPartAndBody(doc);
-			activeBody = Gui::Application::Instance->activeView()->getActiveObject<PartDesign::Body*>(PDBODYKEY);
-			assert(activeBody);
-
-		} else {
-			// empty document with no tip, so do migration
-			_doMigration(doc);
+        if (doc->countObjects() == 0){
+            buildDefaultPartAndBody(doc);
+            activeBody = Gui::Application::Instance->activeView()->getActiveObject<PartDesign::Body*>(PDBODYKEY);
+            assert(activeBody);
+        } else {
+            // empty document with no tip, so do migration
+            _doMigration(doc);
                         activeBody = Gui::Application::Instance->activeView()->getActiveObject<PartDesign::Body*>(PDBODYKEY);
                         assert(activeBody);
                 }
     }
-    else 
+    else
     {
       App::Part *docPart = dynamic_cast<App::Part *>(doc->Tip.getValue());
       assert(docPart);
@@ -430,7 +429,7 @@ void Workbench::_switchToDocument(const App::Document* doc)
         Gui::Application::Instance->activeView()->setActiveObject(docPart, "Part");
       if (docPart->countObjectsOfType(PartDesign::Body::getClassTypeId()) < 1)
         setUpPart(docPart);
-      
+
       PartDesign::Body *tempBody = dynamic_cast<PartDesign::Body *> (docPart->getObjectsOfType(PartDesign::Body::getClassTypeId()).front());
       assert(tempBody);
       PartDesign::Body *viewBody = Gui::Application::Instance->activeView()->getActiveObject<PartDesign::Body*>(PDBODYKEY);
@@ -439,7 +438,7 @@ void Workbench::_switchToDocument(const App::Document* doc)
         activeBody = tempBody;
       else if (!docPart->hasObject(viewBody))
         activeBody = tempBody;
-      
+
       if (activeBody != viewBody)
         Gui::Application::Instance->activeView()->setActiveObject(activeBody, PDBODYKEY);
     }
@@ -463,7 +462,7 @@ void Workbench::slotNewDocument(const App::Document& Doc)
 }
 
 void Workbench::slotFinishRestoreDocument(const App::Document& Doc)
-{    
+{
 //     _switchToDocument(&Doc);
 }
 
@@ -528,7 +527,7 @@ void Workbench::activated()
         "Vertex tools",
         "Part_Box"
     ));
- 
+
     const char* Edge[] = {
         "PartDesign_Fillet",
         "PartDesign_Chamfer",
@@ -544,7 +543,7 @@ void Workbench::activated()
     ));
 
     const char* Face[] = {
-        "PartDesign_NewSketch",        
+        "PartDesign_NewSketch",
         "PartDesign_Fillet",
         "PartDesign_Chamfer",
         "PartDesign_Draft",
@@ -726,7 +725,7 @@ Gui::MenuItem* Workbench::setupMenuBar() const
     Gui::MenuItem* cons = new Gui::MenuItem();
     cons->setCommand("Sketcher constraints");
     SketcherGui::addSketcherWorkbenchConstraints( *cons );
-    
+
     Gui::MenuItem* consaccel = new Gui::MenuItem();
     consaccel->setCommand("Sketcher tools");
     SketcherGui::addSketcherWorkbenchTools(*consaccel);
@@ -823,7 +822,7 @@ Gui::ToolBarItem* Workbench::setupToolBars() const
           << "PartDesign_MultiTransform"
           << "Separator"
           << "PartDesign_Boolean";
-    
+
     return root;
 }
 

--- a/src/Mod/PartDesign/Gui/Workbench.h
+++ b/src/Mod/PartDesign/Gui/Workbench.h
@@ -42,6 +42,10 @@ namespace App {
 	class Part;
 }
 
+namespace Sketcher {
+    class SketchObject;
+}
+
 namespace PartDesignGui {
 
 // pointer to the active assembly object
@@ -74,15 +78,17 @@ public:
     /// Add custom entries to the context menu
     virtual void setupContextMenu(const char* recipient, Gui::MenuItem*) const;
 
-	/** Setup a Part for PartDesign
-	 * This methode is use to populate a Part object with all 
-	 * necesarry PartDesign and base objects to allow the use 
-	 * in PartDesign. Its called from within PartDesign as well 
-	 * as from other modules which wish to set up a Part for PartDesin
-	 * (e.g. Assembly):
-	 */
-	 static PartDesign::Body *setUpPart(const App::Part *);
+    /** Setup a Part for PartDesign
+     * This methode is use to populate a Part object with all
+     * necesarry PartDesign and base objects to allow the use
+     * in PartDesign. Its called from within PartDesign as well
+     * as from other modules which wish to set up a Part for PartDesin
+     * (e.g. Assembly):
+     */
+    static PartDesign::Body *setUpPart(const App::Part *);
 
+    /// Fix sketch support after moving a free sketch into a body
+    static void fixSketchSupport(Sketcher::SketchObject* sketch);
 
 protected:
   Gui::MenuItem* setupMenuBar() const;

--- a/src/Mod/PartDesign/Gui/Workbench.h
+++ b/src/Mod/PartDesign/Gui/Workbench.h
@@ -35,11 +35,11 @@ class ViewProviderDocumentObject;
 }
 
 namespace PartDesign {
-	class Body;
+    class Body;
 }
 
 namespace App {
-	class Part;
+    class Part;
 }
 
 namespace Sketcher {
@@ -115,4 +115,4 @@ private:
 } // namespace PartDesignGui
 
 
-#endif // PARTDESIGN_WORKBENCH_H 
+#endif // PARTDESIGN_WORKBENCH_H


### PR DESCRIPTION
Mostly this fixes two crashes by the 7ee53ba and a small mistake in 72b9048 (It was indicated by a compile warning, I haven't tried to reproduce an error caused by it).

Also it introduces two new functions to Body class: insertFeatureBefore and insertFeatureAfter, which are needed to manipulate order of features in body in the sane way, rather than juggling with the Tip.
They used to set correct support for sketch in fixSketchSupport().
I decided to place the function in the PartDesignGui::Workbench class because I haven't found a better place and it was based on the code from _doMigration() from the same class...

Also I've fixed spaces in all affected files.
