### PR TITLE
3rdParty/salomesmesh: fix build with clang in c11 mode

### DIFF
--- a/src/3rdParty/salomesmesh/src/SMESH/SMESH_MeshEditor.cpp
+++ b/src/3rdParty/salomesmesh/src/SMESH/SMESH_MeshEditor.cpp
@@ -6010,7 +6010,7 @@ SMESH_MeshEditor::Sew_Error
   // sew the border to the side 2
   // ============================
 
-  int nbNodes[]  = { nSide[0].size(), nSide[1].size() };
+  int nbNodes[]  = { (int)nSide[0].size(), (int)nSide[1].size() };
   int maxNbNodes = Max( nbNodes[0], nbNodes[1] );
 
   TListOfListOfNodes nodeGroupsToMerge;


### PR DESCRIPTION
The failure was also reported on the forum: http://forum.freecadweb.org/viewtopic.php?f=20&t=11205&start=40#p90559
