### PR TITLE
Assembly merge master1 fix crashes

### DIFF
--- a/src/Mod/PartDesign/App/FeatureDraft.cpp
+++ b/src/Mod/PartDesign/App/FeatureDraft.cpp
@@ -225,7 +225,7 @@ App::DocumentObjectExecReturn *Draft::execute(void)
                     if (refEdge.IsNull())
                         throw Base::Exception("Failed to extract neutral plane reference edge");
                     BRepAdaptor_Curve c(refEdge);
-                    if (!c.GetType() == GeomAbs_Line)
+                    if (c.GetType() != GeomAbs_Line)
                         throw Base::Exception("Neutral plane reference edge must be linear");
                     double a = c.Line().Angle(gp_Lin(c.Value(c.FirstParameter()), pullDirection));
                     if (std::fabs(a - M_PI_2) > Precision::Confusion())

--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -375,12 +375,17 @@ void CmdPartDesignMoveFeature::activated(int iMsg)
     for (std::vector<App::DocumentObject*>::const_iterator f = features.begin(); f != features.end(); f++) {
         // Find body of this feature
         Part::BodyBase* source = PartDesign::Body::findBodyOf(*f);
-        if (source == target) continue;
-        bool featureIsTip = (source->Tip.getValue() == *f);
+        bool featureIsTip = false;
 
-        // Remove from source body
-        doCommand(Doc,"App.activeDocument().%s.removeFeature(App.activeDocument().%s)",
+        if (source == target) continue;
+
+        // Remove from the source body if the feature belonged to a body
+        if (source) {
+            featureIsTip = (source->Tip.getValue() == *f);
+            doCommand(Doc,"App.activeDocument().%s.removeFeature(App.activeDocument().%s)",
                       source->getNameInDocument(), (*f)->getNameInDocument());
+        }
+
         // Add to target body (always at the Tip)
         doCommand(Doc,"App.activeDocument().%s.addFeature(App.activeDocument().%s)",
                       target->getNameInDocument(), (*f)->getNameInDocument());
@@ -392,7 +397,9 @@ void CmdPartDesignMoveFeature::activated(int iMsg)
             // If we removed the tip of the source body, make the new tip visible
             if (featureIsTip) {
                 App::DocumentObject* prevSolidFeature = source->getPrevSolidFeature();
-                doCommand(Gui,"Gui.activeDocument().show(\"%s\")", prevSolidFeature->getNameInDocument());
+                if (prevSolidFeature) {
+                    doCommand(Gui,"Gui.activeDocument().show(\"%s\")", prevSolidFeature->getNameInDocument());
+                }
             }
 
             // Hide old tip and show new tip (the moved feature) of the target body
@@ -400,6 +407,7 @@ void CmdPartDesignMoveFeature::activated(int iMsg)
             doCommand(Gui,"Gui.activeDocument().hide(\"%s\")", prevSolidFeature->getNameInDocument());
             doCommand(Gui,"Gui.activeDocument().show(\"%s\")", (*f)->getNameInDocument());
         }
+        // TODO: if we are inserting a sketch which wasn't part of any body try to set right support for it
     }
 }
 


### PR DESCRIPTION
This fixes two crashes by the 7ee53ba and a small mistake in 72b9048 (It was indicated by a compile warning, I haven't tried to reproduce an error caused by it).
