### PR TITLE
PartDesign: make Body::isAllowed() assept inly sketches rather other 2D objects

### DIFF
--- a/src/Mod/PartDesign/App/Body.cpp
+++ b/src/Mod/PartDesign/App/Body.cpp
@@ -42,6 +42,7 @@
 #include <Base/Console.h>
 #include <Mod/Part/App/DatumFeature.h>
 #include <Mod/Part/App/PartFeature.h>
+#include <Mod/Sketcher/App/SketchObject.h>
 
 
 using namespace PartDesign;
@@ -224,7 +225,7 @@ const bool Body::isAllowed(const App::DocumentObject* f)
     // TODO: Should we introduce a PartDesign::FeaturePython class? This should then also return true for isSolidFeature()
     return (f->getTypeId().isDerivedFrom(PartDesign::Feature::getClassTypeId()) ||
             f->getTypeId().isDerivedFrom(Part::Datum::getClassTypeId())   ||
-            f->getTypeId().isDerivedFrom(Part::Part2DObject::getClassTypeId()) ||
+            f->getTypeId().isDerivedFrom(Sketcher::SketchObject::getClassTypeId()) ||
             //f->getTypeId().isDerivedFrom(Part::FeaturePython::getClassTypeId()) // trouble with this line on Windows!? Linker fails to find getClassTypeId() of the Part::FeaturePython...
             f->getTypeId().isDerivedFrom(Part::Feature::getClassTypeId())
             );

--- a/src/Mod/PartDesign/App/PreCompiled.h
+++ b/src/Mod/PartDesign/App/PreCompiled.h
@@ -31,10 +31,11 @@
 # define PartDesignExport __declspec(dllexport)
 # define PartExport  __declspec(dllimport)
 # define MeshExport     __declspec(dllimport)
+# define SketcherExport     __declspec(dllimport)
 #else // for Linux
 # define PartDesignExport
 # define PartExport 
-# define MeshExport   
+# define SketcherExport
 #endif
 
 #ifdef _PreComp_


### PR DESCRIPTION
This one is a bit arguable and may be rejected, but for now there is no sense in adding any 2d object different from sketch to a body.
